### PR TITLE
Add NewLocalFileSystem() that wraps zgok.FileSystem around the local filesystem

### DIFF
--- a/localfs.go
+++ b/localfs.go
@@ -1,0 +1,53 @@
+package zgok
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// NewLocalFileSystem returns a FileSystem abstracted
+// over the actual file system. This allows the RestoreFileSystem()
+// to be used transparently with an automatic fallback
+// to the local system when running during development.
+func NewLocalFileSystem(rootPaths ...string) (FileSystem, error) {
+	zfs := &zgokFileSystem{
+		signature: nil,
+		rootPath:  "",
+		fileMap:   make(map[string]File),
+	}
+
+	for _, rp := range rootPaths {
+		err := filepath.Walk(rp, func(p string, fInfo os.FileInfo, err error) error {
+			zgokFile := NewZgokFile()
+			zgokFile.SetPath(p)
+			zgokFile.SetFileInfo(fInfo)
+
+			// Read the file into memory.
+			if !fInfo.IsDir() {
+				f, err := os.Open(p)
+				if err != nil {
+					return err
+				}
+
+				// Copy bytes.
+				buf := new(bytes.Buffer)
+				_, err = io.Copy(buf, f)
+				if err != nil {
+					return err
+				}
+				zgokFile.SetBytes(buf.Bytes())
+
+				// Add the file to the filesystem.
+				zfs.AddFile(zgokFile)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return zfs, nil
+}

--- a/localfs_test.go
+++ b/localfs_test.go
@@ -1,0 +1,28 @@
+package zgok
+
+import (
+	"testing"
+)
+
+func TestNewLocalFileSystem(t *testing.T) {
+	zfs, err := NewLocalFileSystem("./testdata")
+	if err != nil {
+		t.Fatalf("Failed to add local file: %v", err)
+	}
+
+	f, err := zfs.ReadFileString("testdata/foo")
+	if err != nil {
+		t.Fatalf("Failed to testdata/foo read: %v", err)
+	}
+	if f != "foo" {
+		t.Errorf("Expected 'foo' from testdata/foo but got: %v", f)
+	}
+
+	f, err = zfs.ReadFileString("testdata/dir/baz")
+	if err != nil {
+		t.Fatalf("Failed to testdata/dir/baz read: %v", err)
+	}
+	if f != "baz" {
+		t.Errorf("Expected 'baz' from testdata/dir/baz but got: %v", f)
+	}
+}

--- a/zgok.go
+++ b/zgok.go
@@ -109,7 +109,7 @@ func RestoreFileSystem(path string) (FileSystem, error) {
 
 // Add file to file system.
 func (zfs *zgokFileSystem) AddFile(file File) {
-	key := filepath.ToSlash(file.Path())
+	key := filepath.ToSlash(filepath.Join("", file.Path()))
 	zfs.fileMap[key] = file
 }
 


### PR DESCRIPTION
Add NewLocalFileSystem() that wraps zgok.FileSystem around the local filesystem.

This makes it possible to use zgok in development and production equally without having to resort to manual file handling using os.* or ioutil.* functions.